### PR TITLE
Gutter width ZERO

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
     var forEach = Array.prototype.forEach;
     var containerEle = document.querySelector(containerSelector);
     var itemsNodeList = document.querySelectorAll(itemSelector);
-    gutter = gutter || 6;
+    gutter = (gutter || (gutter===0)) ? gutter : 6;
     containerEle.style.width = '';
     var containerWidth = containerEle.getBoundingClientRect().width;
     var firstChildWidth = itemsNodeList[0].getBoundingClientRect().width + gutter;


### PR DESCRIPTION
Even if gutter is set to zero, double pipe evaluates to false... so instead of 0, default value is assigned.
Fixed in this PR.