### PR TITLE
Simplified tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Minimal 2kb zero dependency cascading grid layout",
   "main": "index.js",
   "scripts": {
-    "uglify": "./node_modules/.bin/uglifyjs --comments -m -c -o minigrid.min.js index.js",
+    "uglify": "uglifyjs --comments -m -c -o minigrid.min.js index.js",
     "test": "browserify test.js | tape-run",
     "build": "npm run test && npm run uglify"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "http://alves.im/minigrid",
   "devDependencies": {
+    "phantomjs": "1.9.2-6",
     "browserify": "^11.0.1",
     "tape": "^4.0.2",
     "tape-run": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "uglify": "./node_modules/.bin/uglifyjs --comments -m -c -o minigrid.min.js index.js",
-    "test": "browserify test.js | testling | tap-spec",
+    "test": "browserify test.js | tape-run",
     "build": "npm run test && npm run uglify"
   },
   "repository": {
@@ -31,7 +31,6 @@
   "homepage": "http://alves.im/minigrid",
   "devDependencies": {
     "browserify": "^11.0.1",
-    "tap-spec": "^4.0.2",
     "tape": "^4.0.2",
     "uglify-js": "^2.4.24"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "tape": "^4.0.2",
+    "tape-run": "^1.1.0",
     "uglify-js": "^2.4.24"
   }
 }


### PR DESCRIPTION
* Simplified tests with `tape-run`
* Removed reference to absolute binaries path on `npm` manifest

Fixes #19.