### PR TITLE
Add Turbolinks(Rails) compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,12 @@
       };
     }
 
+    if (typeof(Turbolinks) == 'object') {
+      window.addEventListener('page:load', function () {
+        init(containerEle, itemsNodeList, props);
+      });
+    }
+
   }
 
   function init(containerEle, itemsNodeList, props) {


### PR DESCRIPTION
I'm using `minigrid` in Rails project with `Turbolinks`.

I realized that `minigrid` not work the step below.

- Access page without `.minigrit` element. (whole page reload.)
- Access page with `.minigrid`. (not work) (page chage by turbolinks)

but this step works.

- Access page with `.minigrid` (whole page reload). this works well.
- Access page without `.minigrid`. (page chage by turbolinks)
- Access page with `.minigrid` again. this works well.

Anyway, I added Turbolinks `page:load` event.

Thanks.
