### PR TITLE
getBoundingClientRect() incorrectly reports width for hidden containers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@
     var itemsNodeList = this.props.nodeList;
 
     containerEle.style.width = '';
-    containerEle.style.display = 'initial';
+    containerEle.style.display = 'block';
 
     var forEach = Array.prototype.forEach;
     var containerWidth = containerEle.getBoundingClientRect().width;

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@
     var itemsNodeList = this.props.nodeList;
 
     containerEle.style.width = '';
+    containerEle.style.display = 'initial';
 
     var forEach = Array.prototype.forEach;
     var containerWidth = containerEle.getBoundingClientRect().width;
@@ -97,6 +98,8 @@
 
     });
 
+		containerEle.style.display = '';
+    
     var containerHeight = itemsGutter
       .slice(0)
       .sort(function (a, b) {


### PR DESCRIPTION
It is not possible to use minigrid on hidden container e.g. Bootstrap navbar menu items. Firstly you have to set display to initial, calculate width and height and then reset back